### PR TITLE
fix: change Annotation.confirmed_at type to str instead of datetime

### DIFF
--- a/rossum_api/models/annotation.py
+++ b/rossum_api/models/annotation.py
@@ -1,4 +1,3 @@
-import datetime as dt
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
@@ -35,7 +34,7 @@ class Annotation:
     relations: List[str] = field(default_factory=list)
     pages: List[str] = field(default_factory=list)
     document: Optional[Union[str, Document]] = None
-    confirmed_at: Optional[dt.datetime] = None
+    confirmed_at: Optional[str] = None
     modified_at: Optional[str] = None
     exported_at: Optional[str] = None
     arrived_at: Optional[str] = None


### PR DESCRIPTION
- this raised exception when parsing elis response for methods like `list_all_annotations`
- can this fix be released please? I need the fixed version in releases so I can include its hashed version in requirements for our project