### PR TITLE
Add request_json method to ElisAPIClient

### DIFF
--- a/rossum_api/api_client.py
+++ b/rossum_api/api_client.py
@@ -312,6 +312,8 @@ class APIClient:
 
     async def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
         response = await self._request(method, *args, **kwargs)
+        if response.status_code == 204:
+            return {}
         return response.json()
 
     async def _authenticate(self) -> None:

--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -365,6 +365,12 @@ class ElisAPIClient:
         async for u in self._http_client.fetch_all("groups", ordering, **filters):
             yield dacite.from_dict(UserRole, u)
 
+    async def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
+        """Use to perform requests to seldomly used or experimental endpoints that do not have
+        direct support in the client.
+        """
+        return await self._http_client.request_json(method, *args, **kwargs)
+
     async def _sideload(self, resource: Dict[str, Any], sideloads: Sequence[str]) -> None:
         """The API does not support sideloading when fetching a single resource, we need to load
         it manually.

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -333,3 +333,11 @@ class ElisAPIClientSync:
     ) -> Iterable[UserRole]:
         """https://elis.rossum.ai/api/docs/#list-all-user-roles"""
         return self._iter_over_async(self.elis_api_client.list_all_user_roles(ordering, **filters))
+
+    def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
+        """Use to perform requests to seldomly used or experimental endpoints that do not have
+        direct support in the client.
+        """
+        return self.event_loop.run_until_complete(
+            self.elis_api_client.request_json(method, *args, **kwargs)
+        )

--- a/tests/elis_api_client/test_client_sync.py
+++ b/tests/elis_api_client/test_client_sync.py
@@ -32,3 +32,12 @@ class TestClientSync:
                 ElisAPIClientSync("", "", None)
 
             assert not new_event_loop_mock.called
+
+    def test_request_json(self, elis_client_sync):
+        client, http_client = elis_client_sync
+        http_client.request_json.return_value = {"some": "json"}
+        args = ["some/non/standard/url"]
+        kwargs = {"whatever": "kwarg"}
+        data = client.request_json("GET", *args, **kwargs)
+        assert data == {"some": "json"}
+        http_client.request_json.assert_called_with("GET", *args, **kwargs)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -582,6 +582,15 @@ async def test_request_json_full_url(client, httpx_mock):
 
 
 @pytest.mark.asyncio
+async def test_request_json_204(client, httpx_mock):
+    httpx_mock.add_response(
+        method="DELETE", url="https://elis.rossum.ai/api/v1/workspaces/123", status_code=204
+    )
+    data = await client.request_json("DELETE", "https://elis.rossum.ai/api/v1/workspaces/123")
+    assert data == {}
+
+
+@pytest.mark.asyncio
 async def test_request_repacks_exception(client, httpx_mock):
     httpx_mock.add_response(
         method="GET",


### PR DESCRIPTION
I've used this method when porting E2E Test Runner to `rossum-api` to implement the annotation process since I wasn't sure how common this use case is. I think it's useful to have this method even if we add support for updating annotations to the client.