### PR TITLE
chore: do not run commitizen when there is no commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,23 @@ repos:
     hooks:
       - id: isort
         args: [--settings-path=pyproject.toml, --filter-files]
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.35.0
+  - repo: local
     hooks:
       - id: commitizen-branch
+        name: commitizen conditionally check branch
+        description: >
+          Commitizen fails when there are no new commits. To overcome this, we created
+          tiny wrapper that verifies there are commits to check. 
+
+          Original description from Commitizen:
+          Check all commit messages that are already on the current branch but not the
+          default branch on the origin repository. Useful for checking messages after
+          the fact (e.g., pre-push or in CI) without an expensive check of the entire
+          repository history.
+        entry: ./conditional-commitizen.sh
+        always_run: true
+        language: python
+        minimum_pre_commit_version: "1.4.3"
+        additional_dependencies: [
+          'commitizen',
+        ]

--- a/conditional-commitizen.sh
+++ b/conditional-commitizen.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+log=$(git log origin/HEAD..HEAD | wc -l)
+if [ "$log" -gt 0 ]; then cz check --rev-range origin/HEAD..HEAD; fi


### PR DESCRIPTION
Make it passing when there is no commit.