### PR TITLE
feat: add get_token method to Api client

### DIFF
--- a/rossum_api/api_client.py
+++ b/rossum_api/api_client.py
@@ -317,7 +317,13 @@ class APIClient:
         return response.json()
 
     async def get_token(self, refresh: bool = False) -> str:
-        """Returns the current token. Authenticate if needed."""
+        """Returns the current token. Authentication is done automatically if needed.
+
+        Arguments:
+        ----------
+        refresh
+            force refreshing the token
+        """
         if refresh or self.token is None:
             await self._authenticate()
         return self.token  # type: ignore[return-value] # self.token is set in _authenticate method

--- a/rossum_api/api_client.py
+++ b/rossum_api/api_client.py
@@ -316,6 +316,12 @@ class APIClient:
             return {}
         return response.json()
 
+    async def get_token(self, refresh: bool = False) -> str:
+        """Returns the current token. Authenticate if needed."""
+        if refresh or self.token is None:
+            await self._authenticate()
+        return self.token  # type: ignore[return-value] # self.token is set in _authenticate method
+
     async def _authenticate(self) -> None:
         response = await self.client.post(
             f"{self.base_url}/auth/login",

--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -372,7 +372,13 @@ class ElisAPIClient:
         return await self._http_client.request_json(method, *args, **kwargs)
 
     async def get_token(self, refresh: bool = False) -> str:
-        """Returns the current token. Authentication is done automatically if needed."""
+        """Returns the current token. Authentication is done automatically if needed.
+
+        Arguments:
+        ----------
+        refresh
+            force refreshing the token
+        """
         return await self._http_client.get_token(refresh)
 
     async def _sideload(self, resource: Dict[str, Any], sideloads: Sequence[str]) -> None:

--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -371,6 +371,10 @@ class ElisAPIClient:
         """
         return await self._http_client.request_json(method, *args, **kwargs)
 
+    async def get_token(self, refresh: bool = False) -> str:
+        """Returns the current token. Authentication is done automatically if needed."""
+        return await self._http_client.get_token(refresh)
+
     async def _sideload(self, resource: Dict[str, Any], sideloads: Sequence[str]) -> None:
         """The API does not support sideloading when fetching a single resource, we need to load
         it manually.

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -341,3 +341,7 @@ class ElisAPIClientSync:
         return self.event_loop.run_until_complete(
             self.elis_api_client.request_json(method, *args, **kwargs)
         )
+
+    def get_token(self, refresh: bool = False) -> str:
+        """Returns the current token. Authentication is done automatically if needed."""
+        return self.event_loop.run_until_complete(self.elis_api_client.get_token(refresh))

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -343,5 +343,11 @@ class ElisAPIClientSync:
         )
 
     def get_token(self, refresh: bool = False) -> str:
-        """Returns the current token. Authentication is done automatically if needed."""
+        """Returns the current token. Authentication is done automatically if needed.
+
+        Arguments:
+        ----------
+        refresh
+            force refreshing the token
+        """
         return self.event_loop.run_until_complete(self.elis_api_client.get_token(refresh))

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -120,6 +120,7 @@ EXPECTED_UPLOAD_CONTENT = b'--313131\r\nContent-Disposition: form-data; name="co
 
 CSV_EXPORT = b"meta_file_name,Invoice number\r\nfilename_1.pdf,11111\r\nfilename_2.pdf,22222"
 FAKE_TOKEN = "fake-token"
+OUR_TOKEN = "our-token"
 
 
 def count_calls(func):
@@ -139,22 +140,27 @@ def client():
     return client
 
 
-@pytest.mark.asyncio
-async def test_authenticate(client, httpx_mock):
+@pytest.fixture
+def login_mock(httpx_mock):
     httpx_mock.add_response(
         method="POST",
         url="https://elis.rossum.ai/api/v1/auth/login",
         json={
-            "key": "our-token",
+            "key": OUR_TOKEN,
             "domain": "custom-domain.app.rossum.ai",
         },
     )
+    return httpx_mock
+
+
+@pytest.mark.asyncio
+async def test_authenticate(client, login_mock):
     assert client.token != "our-token"
     await client._authenticate()
     assert client.token == "our-token"
 
     # HTTP 401 is propagated via an exception
-    httpx_mock.add_response(
+    login_mock.add_response(
         method="POST", url="https://elis.rossum.ai/api/v1/auth/login", status_code=401
     )
     with pytest.raises(APIClientError, match="401"):
@@ -615,3 +621,23 @@ async def test_stream_repacks_exception(client, httpx_mock):
         async for w in client._stream("GET", "queues/123/export?format=csv&exported_at=invalid"):
             pass
     assert str(err.value) == "HTTP 404, content: exported_at: Enter a valid date/time"
+
+
+@pytest.mark.asyncio
+async def test_get_token_new(client, login_mock):
+    client.token = None
+    token = await client.get_token()
+    assert token == OUR_TOKEN
+    assert client.token == OUR_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_get_token_old(client):
+    token = await client.get_token()
+    assert token == FAKE_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_get_token_refreshed(client, login_mock):
+    token = await client.get_token(refresh=True)
+    assert token == OUR_TOKEN

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -120,7 +120,7 @@ EXPECTED_UPLOAD_CONTENT = b'--313131\r\nContent-Disposition: form-data; name="co
 
 CSV_EXPORT = b"meta_file_name,Invoice number\r\nfilename_1.pdf,11111\r\nfilename_2.pdf,22222"
 FAKE_TOKEN = "fake-token"
-OUR_TOKEN = "our-token"
+NEW_TOKEN = "our-token"
 
 
 def count_calls(func):
@@ -146,7 +146,7 @@ def login_mock(httpx_mock):
         method="POST",
         url="https://elis.rossum.ai/api/v1/auth/login",
         json={
-            "key": OUR_TOKEN,
+            "key": NEW_TOKEN,
             "domain": "custom-domain.app.rossum.ai",
         },
     )
@@ -627,8 +627,8 @@ async def test_stream_repacks_exception(client, httpx_mock):
 async def test_get_token_new(client, login_mock):
     client.token = None
     token = await client.get_token()
-    assert token == OUR_TOKEN
-    assert client.token == OUR_TOKEN
+    assert token == NEW_TOKEN
+    assert client.token == NEW_TOKEN
 
 
 @pytest.mark.asyncio
@@ -638,6 +638,6 @@ async def test_get_token_old(client):
 
 
 @pytest.mark.asyncio
-async def test_get_token_refreshed(client, login_mock):
+async def test_get_token_force_refresh(client, login_mock):
     token = await client.get_token(refresh=True)
-    assert token == OUR_TOKEN
+    assert token == NEW_TOKEN


### PR DESCRIPTION
Simple method for obtaining current token. 
- Client is authenticated first if no token exist. 
- Possibility to force refreshing.

Useful for situations, where you need to just obtain token from username/password and pass it elsewhere (without calling any rossum api endpoint).

We (exe) use this in a fastAPI path function dependency, that obtains rossum token from username/password obtained from hook secrets.

e.g. function:
```
async def _get_rossum_token_from_credentials(user: str, password: str, base_url: str) -> str:
    """Get token from Rossum API."""
    client = ElisAPIClient(
        username=user, password=password, base_url=f"{base_url}/api/v1"
    )
    return await client.get_token()
```
