### PR TITLE
fix(models:document): define `creator` attribute as optional

### DIFF
--- a/rossum_api/models/document.py
+++ b/rossum_api/models/document.py
@@ -12,7 +12,7 @@ class Document:
     parent: Optional[str]
     email: Optional[str]
     mime_type: str
-    creator: str
+    creator: Optional[str]
     created_at: str
     arrived_at: str
     original_file_name: str


### PR DESCRIPTION
This created hard-to-debug problem because some of the documents being fetched had `creator==None`.

I think we should maybe consider less strict validation for our internal data models unless we are super confident all are always up to date and correct. Because this can cause quite annoying problems in client code.