### PR TITLE
fix(models:hook): define attributes `guide`, `read_more_url` and `extension_image_url` as optional

### DIFF
--- a/rossum_api/models/hook.py
+++ b/rossum_api/models/hook.py
@@ -10,9 +10,9 @@ class Hook:
     active: bool
     config: Dict[str, Any]
     test: Dict[str, Any]
-    guide: str
-    read_more_url: str
-    extension_image_url: str
+    guide: Optional[str]
+    read_more_url: Optional[str]
+    extension_image_url: Optional[str]
     type: str = "webhook"
     metadata: Dict[str, Any] = field(default_factory=dict)
     queues: List[str] = field(default_factory=list)


### PR DESCRIPTION
When retrieving valid hook object, I got validation errors, because Elis send `None` in these attributes. The validation needs to be more benevolent for this models 
(this already happened also for other models, we should probably check the annotations in near future, because these are blocking issues). 