### PR TITLE
fix(rossun_api/sideloading): use singular form when refering attribute of the sideload

### DIFF
--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -386,7 +386,7 @@ class ElisAPIClient:
         it manually.
         """
         sideload_tasks = [
-            asyncio.create_task(self._http_client.request_json("GET", resource[sideload]))
+            asyncio.create_task(self._http_client.request_json("GET", resource[sideload.rstrip("s")]))
             for sideload in sideloads
         ]
         sideloaded_jsons = await asyncio.gather(*sideload_tasks)


### PR DESCRIPTION
This is handled correctly for `list_all_annotations` but not for `retrieve_annotation` resulting in key exceptions when sideloading anything except `content`.