### PR TITLE
feat(rossum_sdk/api_client): add `request` method to ElisApiClient

### DIFF
--- a/rossum_api/api_client.py
+++ b/rossum_api/api_client.py
@@ -316,6 +316,10 @@ class APIClient:
             return {}
         return response.json()
 
+    async def request(self, method: str, *args, **kwargs) -> httpx.Response:
+        response = await self._request(method, *args, **kwargs)
+        return response
+
     async def get_token(self, refresh: bool = False) -> str:
         """Returns the current token. Authentication is done automatically if needed.
 

--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -5,6 +5,7 @@ import typing
 from enum import Enum
 
 import aiofiles
+import httpx
 
 if typing.TYPE_CHECKING:
     import pathlib
@@ -367,9 +368,15 @@ class ElisAPIClient:
 
     async def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
         """Use to perform requests to seldomly used or experimental endpoints that do not have
-        direct support in the client.
+        direct support in the client and return JSON.
         """
         return await self._http_client.request_json(method, *args, **kwargs)
+
+    async def request(self, method: str, *args, **kwargs) -> httpx.Response:
+        """Use to perform requests to seldomly used or experimental endpoints that do not have
+        direct support in the client and return the raw response.
+        """
+        return await self._http_client.request(method, *args, **kwargs)
 
     async def get_token(self, refresh: bool = False) -> str:
         """Returns the current token. Authentication is done automatically if needed.

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import typing
 
+import httpx
+
 if typing.TYPE_CHECKING:
     import pathlib
     from typing import (
@@ -336,10 +338,18 @@ class ElisAPIClientSync:
 
     def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
         """Use to perform requests to seldomly used or experimental endpoints that do not have
-        direct support in the client.
+        direct support in the client and return JSON.
         """
         return self.event_loop.run_until_complete(
             self.elis_api_client.request_json(method, *args, **kwargs)
+        )
+
+    def request(self, method: str, *args, **kwargs) -> httpx.Response:
+        """Use to perform requests to seldomly used or experimental endpoints that do not have
+        direct support in the client and return the raw response.
+        """
+        return self.event_loop.run_until_complete(
+            self.elis_api_client.request(method, *args, **kwargs)
         )
 
     def get_token(self, refresh: bool = False) -> str:

--- a/tests/elis_api_client/test_client_sync.py
+++ b/tests/elis_api_client/test_client_sync.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from mock import patch
 from mock.mock import MagicMock
@@ -41,3 +42,14 @@ class TestClientSync:
         data = client.request_json("GET", *args, **kwargs)
         assert data == {"some": "json"}
         http_client.request_json.assert_called_with("GET", *args, **kwargs)
+        
+    def test_request(self, elis_client_sync):
+        client, http_client = elis_client_sync
+        http_client.request.return_value = httpx.Response(200, content=b"some content")
+        args = ["some/non/standard/url"]
+        kwargs = {"whatever": "kwarg"}
+        data = client.request("GET", *args, **kwargs)
+        assert data.content == b"some content"
+        http_client.request.assert_called_with("GET", *args, **kwargs)
+            
+        

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -595,6 +595,15 @@ async def test_request_json_204(client, httpx_mock):
     data = await client.request_json("DELETE", "https://elis.rossum.ai/api/v1/workspaces/123")
     assert data == {}
 
+@pytest.mark.asyncio
+async def test_request_binary_data(client, httpx_mock):
+    httpx_mock.add_response(
+        method="GET", url="https://elis.rossum.ai/api/v1/pages/123/preview", content=b"binary data"
+    )
+    data = await client.request(
+        "GET", "https://elis.rossum.ai/api/v1/pages/123/preview"
+    )
+    assert data.content == b"binary data"
 
 @pytest.mark.asyncio
 async def test_request_repacks_exception(client, httpx_mock):


### PR DESCRIPTION
Added method to enable requesting raw binary data from endpoints such as `pages/<id>/preview`.