### PR TITLE
feat(elis_api_client): add generic method for requests to paginated resources

### DIFF
--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -364,6 +364,14 @@ class ElisAPIClient:
         async for u in self._http_client.fetch_all("groups", ordering, **filters):
             yield dacite.from_dict(UserRole, u)
 
+    # ##### GENERIC METHODS #####
+    async def request_paginated(self, resource: str, *args, **kwargs) -> AsyncIterable[dict]:
+        """Use to perform requests to seldomly used or experimental endpoints with paginated response that do not have
+        direct support in the client and return iterable.
+        """
+        async for element in self._http_client.fetch_all(resource, *args, **kwargs):
+            yield element
+
     async def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
         """Use to perform requests to seldomly used or experimental endpoints that do not have
         direct support in the client and return JSON.

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -335,6 +335,14 @@ class ElisAPIClientSync:
         """https://elis.rossum.ai/api/docs/#list-all-user-roles."""
         return self._iter_over_async(self.elis_api_client.list_all_user_roles(ordering, **filters))
 
+    def request_paginated(self, resource: str, *args, **kwargs) -> Iterable[dict]:
+        """Use to perform requests to seldomly used or experimental endpoints with paginated response that do not have
+        direct support in the client and return iterable.
+        """
+        return self._iter_over_async(
+            self.elis_api_client.request_paginated(resource, *args, **kwargs)
+        )
+
     def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
         """Use to perform requests to seldomly used or experimental endpoints that do not have
         direct support in the client and return JSON.

--- a/tests/elis_api_client/test_client_sync.py
+++ b/tests/elis_api_client/test_client_sync.py
@@ -36,6 +36,13 @@ class TestClientSync:
 
             assert not new_event_loop_mock.called
 
+    def test_request_paginated(self, elis_client_sync, mock_generator):
+        client, http_client = elis_client_sync
+        http_client.fetch_all.return_value = mock_generator({"some": "json"})
+        kwargs = {"whatever": "kwarg"}
+        data = client.request_paginated("hook_templates", **kwargs)
+        assert list(data) == [{"some": "json"}]
+
     def test_request_json(self, elis_client_sync):
         client, http_client = elis_client_sync
         http_client.request_json.return_value = {"some": "json"}


### PR DESCRIPTION
Some endpoints that returns paginated responses are not supported by the client. To not be forced to periodically update the client and be more future proof, I added generic method for paginated responses.

I need it in my case for "hook_templates". Currently I have to do very ugly hack like this:
```
hook_templates = list(
        elis_client._iter_over_async(
            elis_client.elis_api_client._http_client.fetch_all(f"hook_templates")
        )
    )
```

With this MR, I will be able to just do:
```
hook_templates = list(elis_client.request_paginated("hook_templates"))
```