### PR TITLE
fix(models): make queue model compliant with API docs

### DIFF
--- a/rossum_api/models/queue.py
+++ b/rossum_api/models/queue.py
@@ -9,7 +9,7 @@ class Queue:
     id: int
     name: str
     url: str
-    workspace: str
+    workspace: Optional[str]
     connector: Optional[str]
     schema: str
     inbox: Optional[str]

--- a/rossum_api/models/queue.py
+++ b/rossum_api/models/queue.py
@@ -24,7 +24,7 @@ class Queue:
     automation_level: str = "never"
     default_score_threshold: float = 0.8
     locale: str = "en_GB"
-    metadata: Dict[str, str] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
     settings: Dict[str, Any] = field(default_factory=dict)
     dedicated_engine: Optional[Union[str, Dict[str, Any]]] = None
     generic_engine: Optional[Union[str, Dict[str, Any]]] = None


### PR DESCRIPTION
# Metadata
The [docs](https://elis.rossum.ai/api/docs/#metadata) say that `metadata` can be a custom JSON object, but the `Queue` model (this one only) restricts it to `dict[str, str]`. This causes confusing uncaught exceptions when fetching queues with more complex metadata objects like:
```python
WrongTypeError(field_path=field.name, field_type=field_type, value=value)
dacite.exceptions.WrongTypeError: wrong value type for field "metadata" - should be "Dict" instead of value "{'queueTemplate': 'taxinvoiceeu', 'distributive_fields': {'line_items': {'item_desc': {'schema_ids': ['article'], 'preferred_direction': 'downwards'}, 'item_number_plate': {'schema_ids': ['number_plate'], 'preferred_direction': 'downwards'}}}}" of type "dict"
```
# Workspace
The [docs](https://elis.rossum.ai/api/docs/#queue) say:
```
Workspace in which the queue should be placed (it can be set to `null`, but bare in mind that it will make the queue invisible in the Rossum UI and it may cause some unexpected consequences)
```
Similar exception is raised for such queues when fetching them using the client.