### PR TITLE
feat: export public interface in root package

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Async version:
 
 ```python
 import asyncio
-from rossum_api.elis_api_client import ElisAPIClient
+from rossum_api import ElisAPIClient
 
 WORKSPACE = {
     "name": "Rossum Client NG Test",
@@ -77,7 +77,7 @@ asyncio.run(main_with_async_client())
 Sync version:
 
 ```python
-from rossum_api.elis_api_client_sync import ElisAPIClientSync
+from rossum_api import ElisAPIClientSync
 
 WORKSPACE = {
     "name": "Rossum Client NG Test",

--- a/rossum_api/__init__.py
+++ b/rossum_api/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from rossum_api.api_client import APIClientError
+from rossum_api.elis_api_client import ElisAPIClient, ExportFileFormats
+from rossum_api.elis_api_client_sync import ElisAPIClientSync
+
+__all__ = (
+    "APIClientError",
+    "ElisAPIClient",
+    "ElisAPIClientSync",
+    "ExportFileFormats",
+)

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import typing
 
-from rossum_api.elis_api_client import ElisAPIClient
+from rossum_api import ElisAPIClient
 
 if typing.TYPE_CHECKING:
     import pathlib
@@ -23,8 +23,8 @@ if typing.TYPE_CHECKING:
 
     import httpx
 
+    from rossum_api import ExportFileFormats
     from rossum_api.api_client import APIClient
-    from rossum_api.elis_api_client import ExportFileFormats
     from rossum_api.models.annotation import Annotation
     from rossum_api.models.connector import Connector
     from rossum_api.models.hook import Hook

--- a/test.py
+++ b/test.py
@@ -11,9 +11,8 @@ import random
 
 import aiofiles
 
+from rossum_api import ElisAPIClient, ElisAPIClientSync
 from rossum_api.api_client import APIClient
-from rossum_api.elis_api_client import ElisAPIClient
-from rossum_api.elis_api_client_sync import ElisAPIClientSync
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,8 @@ import pytest
 import pytest_asyncio
 from mock import MagicMock
 
+from rossum_api import ElisAPIClient, ElisAPIClientSync
 from rossum_api.api_client import APIClient
-from rossum_api.elis_api_client import ElisAPIClient
-from rossum_api.elis_api_client_sync import ElisAPIClientSync
 
 
 @pytest.fixture

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -8,7 +8,7 @@ import aiofiles
 import pytest
 from aiofiles import os as aios
 
-from rossum_api.elis_api_client import ElisAPIClient
+from rossum_api import ElisAPIClient
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/tests/elis_api_client/test_client_sync.py
+++ b/tests/elis_api_client/test_client_sync.py
@@ -5,7 +5,8 @@ import pytest
 from mock import patch
 from mock.mock import MagicMock
 
-from rossum_api.elis_api_client_sync import AsyncRuntimeError, ElisAPIClientSync
+from rossum_api import ElisAPIClientSync
+from rossum_api.elis_api_client_sync import AsyncRuntimeError
 
 
 class TestClientSync:


### PR DESCRIPTION
Importing stuff from internal subpackages like
```python
from rossum_api.elis_api_client import ElisAPIClient
from rossum_api.api_client import APIClientError
```
always feels bad. :( 

The standard is to "export" public interface in the root package like
```python
from httpx import AsyncClient, HTTPStatusError
```