### PR TITLE
refactor: Use an enum instead of strings to identify API resources

### DIFF
--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -166,7 +166,7 @@ class ElisAPIClientSync:
         )
 
     def retrieve_own_organization(self) -> Organization:
-        """Retrive organization of currently logged in user."""
+        """Retrieve organization of currently logged in user."""
         return self.event_loop.run_until_complete(self.elis_api_client.retrieve_own_organization())
 
     # ##### SCHEMAS #####
@@ -350,13 +350,11 @@ class ElisAPIClientSync:
         """https://elis.rossum.ai/api/docs/#list-all-user-roles."""
         return self._iter_over_async(self.elis_api_client.list_all_user_roles(ordering, **filters))
 
-    def request_paginated(self, resource: str, *args, **kwargs) -> Iterable[dict]:
+    def request_paginated(self, url: str, *args, **kwargs) -> Iterable[dict]:
         """Use to perform requests to seldomly used or experimental endpoints with paginated response that do not have
         direct support in the client and return iterable.
         """
-        return self._iter_over_async(
-            self.elis_api_client.request_paginated(resource, *args, **kwargs)
-        )
+        return self._iter_over_async(self.elis_api_client.request_paginated(url, *args, **kwargs))
 
     def request_json(self, method: str, *args, **kwargs) -> Dict[str, Any]:
         """Use to perform requests to seldomly used or experimental endpoints that do not have

--- a/tests/elis_api_client/test_annotations.py
+++ b/tests/elis_api_client/test_annotations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from mock.mock import MagicMock, patch
 
+from rossum_api.api_client import Resource
 from rossum_api.models.annotation import Annotation
 from rossum_api.models.automation_blocker import AutomationBlocker, AutomationBlockerContent
 from rossum_api.models.document import Document
@@ -128,7 +129,7 @@ class TestAnnotations:
         async for a in annotations:
             assert a == Annotation(**dummy_annotation)
 
-        http_client.fetch_all.assert_called_with("annotations", (), (), ())
+        http_client.fetch_all.assert_called_with(Resource.Annotation, (), (), ())
 
     async def test_list_all_annotations_with_sideloads(
         self, elis_client, dummy_annotation_with_sideloads, mock_generator
@@ -158,7 +159,7 @@ class TestAnnotations:
             assert a == annotation
 
         http_client.fetch_all.assert_called_with(
-            "annotations",
+            Resource.Annotation,
             (),
             ["documents", "automation_blockers", "content", "modifiers"],
             ["325164"],
@@ -187,7 +188,7 @@ class TestAnnotations:
         async for a in annotations:
             assert a == Annotation(**dummy_annotation)
 
-        http_client.fetch_all.assert_called_with(
+        http_client.fetch_all_by_url.assert_called_with(
             "annotations/search",
             (),
             (),
@@ -204,7 +205,7 @@ class TestAnnotations:
 
         assert annotation == Annotation(**dummy_annotation)
 
-        http_client.fetch_one.assert_called_with("annotations", aid)
+        http_client.fetch_one.assert_called_with(Resource.Annotation, aid)
 
     async def test_retrieve_annotation_with_sideloads(self, elis_client, dummy_annotation):
         client, http_client = elis_client
@@ -216,7 +217,7 @@ class TestAnnotations:
 
         assert annotation == Annotation(**{**dummy_annotation, "content": []})
 
-        http_client.fetch_one.assert_called_with("annotations", aid)
+        http_client.fetch_one.assert_called_with(Resource.Annotation, aid)
 
     async def test_poll_annotation(self, elis_client, dummy_annotation):
         def is_imported(annotation):
@@ -252,7 +253,7 @@ class TestAnnotations:
 
         assert annotation == Annotation(**dummy_annotation)
 
-        http_client.replace.assert_called_with("annotations", aid, data)
+        http_client.replace.assert_called_with(Resource.Annotation, aid, data)
 
     async def test_update_part_annotation(self, elis_client, dummy_annotation):
         client, http_client = elis_client
@@ -266,7 +267,7 @@ class TestAnnotations:
 
         assert annotation == Annotation(**dummy_annotation)
 
-        http_client.update.assert_called_with("annotations", aid, data)
+        http_client.update.assert_called_with(Resource.Annotation, aid, data)
 
 
 class TestAnnotationsSync:
@@ -279,7 +280,7 @@ class TestAnnotationsSync:
         for a in annotations:
             assert a == Annotation(**dummy_annotation)
 
-        http_client.fetch_all.assert_called_with("annotations", (), (), ())
+        http_client.fetch_all.assert_called_with(Resource.Annotation, (), (), ())
 
     def test_list_all_annotations_with_sideloads(
         self, elis_client_sync, dummy_annotation_with_sideloads, mock_generator
@@ -309,7 +310,7 @@ class TestAnnotationsSync:
             assert a == annotation
 
         http_client.fetch_all.assert_called_with(
-            "annotations",
+            Resource.Annotation,
             (),
             ["documents", "automation_blockers", "content", "modifiers"],
             ["325164"],
@@ -338,7 +339,7 @@ class TestAnnotationsSync:
         for a in annotations:
             assert a == Annotation(**dummy_annotation)
 
-        http_client.fetch_all.assert_called_with(
+        http_client.fetch_all_by_url.assert_called_with(
             "annotations/search",
             (),
             (),
@@ -355,7 +356,7 @@ class TestAnnotationsSync:
 
         assert annotation == Annotation(**dummy_annotation)
 
-        http_client.fetch_one.assert_called_with("annotations", aid)
+        http_client.fetch_one.assert_called_with(Resource.Annotation, aid)
 
     def test_retrieve_annotation_with_sideloads(self, elis_client_sync, dummy_annotation):
         client, http_client = elis_client_sync
@@ -367,7 +368,7 @@ class TestAnnotationsSync:
 
         assert annotation == Annotation(**{**dummy_annotation, "content": []})
 
-        http_client.fetch_one.assert_called_with("annotations", aid)
+        http_client.fetch_one.assert_called_with(Resource.Annotation, aid)
 
     def test_poll_annotation(self, elis_client_sync, dummy_annotation):
         def is_imported(annotation):
@@ -403,7 +404,7 @@ class TestAnnotationsSync:
 
         assert annotation == Annotation(**dummy_annotation)
 
-        http_client.replace.assert_called_with("annotations", aid, data)
+        http_client.replace.assert_called_with(Resource.Annotation, aid, data)
 
     def test_update_part_annotation(self, elis_client_sync, dummy_annotation):
         client, http_client = elis_client_sync
@@ -417,4 +418,4 @@ class TestAnnotationsSync:
 
         assert annotation == Annotation(**dummy_annotation)
 
-        http_client.update.assert_called_with("annotations", aid, data)
+        http_client.update.assert_called_with(Resource.Annotation, aid, data)

--- a/tests/elis_api_client/test_client_sync.py
+++ b/tests/elis_api_client/test_client_sync.py
@@ -39,7 +39,7 @@ class TestClientSync:
 
     def test_request_paginated(self, elis_client_sync, mock_generator):
         client, http_client = elis_client_sync
-        http_client.fetch_all.return_value = mock_generator({"some": "json"})
+        http_client.fetch_all_by_url.return_value = mock_generator({"some": "json"})
         kwargs = {"whatever": "kwarg"}
         data = client.request_paginated("hook_templates", **kwargs)
         assert list(data) == [{"some": "json"}]

--- a/tests/elis_api_client/test_connectors.py
+++ b/tests/elis_api_client/test_connectors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from rossum_api.api_client import Resource
 from rossum_api.models.connector import Connector
 
 
@@ -32,7 +33,7 @@ class TestUsers:
         async for c in connectors:
             assert c == Connector(**dummy_connector)
 
-        http_client.fetch_all.assert_called_with("connectors", ())
+        http_client.fetch_all.assert_called_with(Resource.Connector, ())
 
     @pytest.mark.asyncio
     async def test_retrieve_connector(self, elis_client, dummy_connector):
@@ -44,7 +45,7 @@ class TestUsers:
 
         assert connector == Connector(**dummy_connector)
 
-        http_client.fetch_one.assert_called_with("connectors", cid)
+        http_client.fetch_one.assert_called_with(Resource.Connector, cid)
 
     async def test_create_new_connector(self, elis_client, dummy_connector):
         client, http_client = elis_client
@@ -60,7 +61,7 @@ class TestUsers:
 
         assert connector == Connector(**dummy_connector)
 
-        http_client.create.assert_called_with("connectors", data)
+        http_client.create.assert_called_with(Resource.Connector, data)
 
 
 class TestUsersSync:
@@ -73,7 +74,7 @@ class TestUsersSync:
         for c in connectors:
             assert c == Connector(**dummy_connector)
 
-        http_client.fetch_all.assert_called_with("connectors", ())
+        http_client.fetch_all.assert_called_with(Resource.Connector, ())
 
     def test_retrieve_connector(self, elis_client_sync, dummy_connector):
         client, http_client = elis_client_sync
@@ -84,7 +85,7 @@ class TestUsersSync:
 
         assert connector == Connector(**dummy_connector)
 
-        http_client.fetch_one.assert_called_with("connectors", cid)
+        http_client.fetch_one.assert_called_with(Resource.Connector, cid)
 
     def test_create_new_connector(self, elis_client_sync, dummy_connector):
         client, http_client = elis_client_sync
@@ -100,4 +101,4 @@ class TestUsersSync:
 
         assert connector == Connector(**dummy_connector)
 
-        http_client.create.assert_called_with("connectors", data)
+        http_client.create.assert_called_with(Resource.Connector, data)

--- a/tests/elis_api_client/test_hooks.py
+++ b/tests/elis_api_client/test_hooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from rossum_api.api_client import Resource
 from rossum_api.models.hook import Hook
 
 
@@ -49,7 +50,7 @@ class TestHooks:
         async for h in hooks:
             assert h == Hook(**dummy_hook)
 
-        http_client.fetch_all.assert_called_with("hooks", ())
+        http_client.fetch_all.assert_called_with(Resource.Hook, ())
 
     async def test_retrieve_user(self, elis_client, dummy_hook):
         client, http_client = elis_client
@@ -60,7 +61,7 @@ class TestHooks:
 
         assert hook == Hook(**dummy_hook)
 
-        http_client.fetch_one.assert_called_with("hooks", uid)
+        http_client.fetch_one.assert_called_with(Resource.Hook, uid)
 
     async def test_create_new_user(self, elis_client, dummy_hook):
         client, http_client = elis_client
@@ -76,7 +77,7 @@ class TestHooks:
 
         assert hook == Hook(**dummy_hook)
 
-        http_client.create.assert_called_with("hooks", data)
+        http_client.create.assert_called_with(Resource.Hook, data)
 
 
 class TestHooksAsync:
@@ -89,7 +90,7 @@ class TestHooksAsync:
         for h in hooks:
             assert h == Hook(**dummy_hook)
 
-        http_client.fetch_all.assert_called_with("hooks", ())
+        http_client.fetch_all.assert_called_with(Resource.Hook, ())
 
     def test_retrieve_user(self, elis_client_sync, dummy_hook):
         client, http_client = elis_client_sync
@@ -100,7 +101,7 @@ class TestHooksAsync:
 
         assert hook == Hook(**dummy_hook)
 
-        http_client.fetch_one.assert_called_with("hooks", uid)
+        http_client.fetch_one.assert_called_with(Resource.Hook, uid)
 
     def test_create_new_user(self, elis_client_sync, dummy_hook):
         client, http_client = elis_client_sync
@@ -116,4 +117,4 @@ class TestHooksAsync:
 
         assert hook == Hook(**dummy_hook)
 
-        http_client.create.assert_called_with("hooks", data)
+        http_client.create.assert_called_with(Resource.Hook, data)

--- a/tests/elis_api_client/test_inboxes.py
+++ b/tests/elis_api_client/test_inboxes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from rossum_api.api_client import Resource
 from rossum_api.models.inbox import Inbox
 
 
@@ -52,7 +53,7 @@ class TestInboxes:
 
         assert inbox == Inbox(**dummy_inbox)
 
-        http_client.create.assert_called_with("inboxes", data)
+        http_client.create.assert_called_with(Resource.Inbox, data)
 
 
 class TestInboxesSync:
@@ -72,4 +73,4 @@ class TestInboxesSync:
 
         assert inbox == Inbox(**dummy_inbox)
 
-        http_client.create.assert_called_with("inboxes", data)
+        http_client.create.assert_called_with(Resource.Inbox, data)

--- a/tests/elis_api_client/test_organizations.py
+++ b/tests/elis_api_client/test_organizations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from mock import call
 
+from rossum_api.api_client import Resource
 from rossum_api.models.organization import Organization
 
 
@@ -35,7 +36,7 @@ class TestOrganizations:
         async for o in organizations:
             assert o == Organization(**dummy_organization)
 
-        http_client.fetch_all.assert_called_with("organizations", ())
+        http_client.fetch_all.assert_called_with(Resource.Organization, ())
 
     async def test_retrieve_organization(self, elis_client, dummy_organization):
         client, http_client = elis_client
@@ -46,7 +47,7 @@ class TestOrganizations:
 
         assert organization == Organization(**dummy_organization)
 
-        http_client.fetch_one.assert_called_with("organizations", oid)
+        http_client.fetch_one.assert_called_with(Resource.Organization, oid)
 
     async def test_retrieve_own_organization(self, elis_client, dummy_user, dummy_organization):
         client, http_client = elis_client
@@ -57,7 +58,7 @@ class TestOrganizations:
         assert organization == Organization(**dummy_organization)
 
         http_client.fetch_one.assert_has_calls(
-            [call("auth", "user"), call("organizations", "406")]
+            [call(Resource.Auth, "user"), call(Resource.Organization, "406")]
         )
 
 
@@ -71,7 +72,7 @@ class TestOrganizationsSync:
         for o in organizations:
             assert o == Organization(**dummy_organization)
 
-        http_client.fetch_all.assert_called_with("organizations", ())
+        http_client.fetch_all.assert_called_with(Resource.Organization, ())
 
     def test_retrieve_organization(self, elis_client_sync, dummy_organization):
         client, http_client = elis_client_sync
@@ -82,7 +83,7 @@ class TestOrganizationsSync:
 
         assert organization == Organization(**dummy_organization)
 
-        http_client.fetch_one.assert_called_with("organizations", oid)
+        http_client.fetch_one.assert_called_with(Resource.Organization, oid)
 
     def test_retrieve_own_organization(self, elis_client_sync, dummy_user, dummy_organization):
         client, http_client = elis_client_sync
@@ -93,5 +94,5 @@ class TestOrganizationsSync:
         assert organization == Organization(**dummy_organization)
 
         http_client.fetch_one.assert_has_calls(
-            [call("auth", "user"), call("organizations", "406")]
+            [call(Resource.Auth, "user"), call(Resource.Organization, "406")]
         )

--- a/tests/elis_api_client/test_queues.py
+++ b/tests/elis_api_client/test_queues.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from mock import MagicMock, call, patch
 
+from rossum_api.api_client import Resource
 from rossum_api.models.annotation import Annotation
 from rossum_api.models.queue import Queue
 
@@ -104,7 +105,7 @@ class TestQueues:
         async for q in queues:
             assert q == Queue(**dummy_queue)
 
-        http_client.fetch_all.assert_called_with("queues", ())
+        http_client.fetch_all.assert_called_with(Resource.Queue, ())
 
     async def test_retrieve_queue(self, elis_client, dummy_queue):
         client, http_client = elis_client
@@ -115,7 +116,7 @@ class TestQueues:
 
         assert queue == Queue(**dummy_queue)
 
-        http_client.fetch_one.assert_called_with("queues", qid)
+        http_client.fetch_one.assert_called_with(Resource.Queue, qid)
 
     async def test_create_new_queue(self, elis_client, dummy_queue):
         client, http_client = elis_client
@@ -130,7 +131,7 @@ class TestQueues:
 
         assert queue == Queue(**dummy_queue)
 
-        http_client.create.assert_called_with("queues", data)
+        http_client.create.assert_called_with(Resource.Queue, data)
 
     async def test_delete_queue(self, elis_client, dummy_queue):
         client, http_client = elis_client
@@ -139,7 +140,7 @@ class TestQueues:
         qid = dummy_queue["id"]
         await client.delete_queue(qid)
 
-        http_client.delete.assert_called_with("queues", qid)
+        http_client.delete.assert_called_with(Resource.Queue, qid)
 
     async def test_import_document(self, elis_client):
         client, http_client = elis_client
@@ -188,8 +189,8 @@ class TestQueues:
 
         assert annotation_ids == [111, 222]
         calls = [
-            call("queues", 123, open_mock_first, "document.pdf", {"a": 1}, {"b": 2}),
-            call("queues", 123, open_mock_second, "document 🎁.pdf", {"a": 1}, {"b": 2}),
+            call(Resource.Queue, 123, open_mock_first, "document.pdf", {"a": 1}, {"b": 2}),
+            call(Resource.Queue, 123, open_mock_second, "document 🎁.pdf", {"a": 1}, {"b": 2}),
         ]
         http_client.upload.assert_has_calls(calls, any_order=True)
 
@@ -203,7 +204,7 @@ class TestQueues:
         async for a in client.export_annotations_to_json(queue_id=qid):
             assert a == Annotation(**dummy_annotation)
 
-        http_client.export.assert_called_with("queues", qid, export_format)
+        http_client.export.assert_called_with(Resource.Queue, qid, export_format)
 
     async def test_export_annotations_to_file(self, elis_client, mock_file_read):
         client, http_client = elis_client
@@ -218,7 +219,7 @@ class TestQueues:
         ):
             result += a
 
-        http_client.export.assert_called_with("queues", qid, export_format)
+        http_client.export.assert_called_with(Resource.Queue, qid, export_format)
 
         with open("tests/data/annotation_export.xml", "rb") as fp:
             for i, line in enumerate(fp.read()):
@@ -235,7 +236,7 @@ class TestQueuesSync:
         for q in queues:
             assert q == Queue(**dummy_queue)
 
-        http_client.fetch_all.assert_called_with("queues", ())
+        http_client.fetch_all.assert_called_with(Resource.Queue, ())
 
     def test_retrieve_queue(self, elis_client_sync, dummy_queue):
         client, http_client = elis_client_sync
@@ -246,7 +247,7 @@ class TestQueuesSync:
 
         assert queue == Queue(**dummy_queue)
 
-        http_client.fetch_one.assert_called_with("queues", qid)
+        http_client.fetch_one.assert_called_with(Resource.Queue, qid)
 
     def test_create_new_queue(self, elis_client_sync, dummy_queue):
         client, http_client = elis_client_sync
@@ -261,7 +262,7 @@ class TestQueuesSync:
 
         assert queue == Queue(**dummy_queue)
 
-        http_client.create.assert_called_with("queues", data)
+        http_client.create.assert_called_with(Resource.Queue, data)
 
     def test_import_document(self, elis_client_sync):
         client, http_client = elis_client_sync
@@ -310,8 +311,8 @@ class TestQueuesSync:
 
         assert annotation_ids == [111, 222]
         calls = [
-            call("queues", 123, open_mock_first, "document.pdf", {"a": 1}, {"b": 2}),
-            call("queues", 123, open_mock_second, "document 🎁.pdf", {"a": 1}, {"b": 2}),
+            call(Resource.Queue, 123, open_mock_first, "document.pdf", {"a": 1}, {"b": 2}),
+            call(Resource.Queue, 123, open_mock_second, "document 🎁.pdf", {"a": 1}, {"b": 2}),
         ]
 
         http_client.upload.assert_has_calls(calls, any_order=True)
@@ -323,7 +324,7 @@ class TestQueuesSync:
         qid = dummy_queue["id"]
         client.delete_queue(qid)
 
-        http_client.delete.assert_called_with("queues", qid)
+        http_client.delete.assert_called_with(Resource.Queue, qid)
 
     def test_export_annotations_to_json(self, elis_client_sync, dummy_annotation, mock_generator):
         client, http_client = elis_client_sync
@@ -335,7 +336,7 @@ class TestQueuesSync:
         for a in client.export_annotations_to_json(queue_id=qid):
             assert a == Annotation(**dummy_annotation)
 
-        http_client.export.assert_called_with("queues", qid, export_format)
+        http_client.export.assert_called_with(Resource.Queue, qid, export_format)
 
     def test_export_annotations_to_file(self, elis_client_sync, mock_file_read):
         client, http_client = elis_client_sync
@@ -348,7 +349,7 @@ class TestQueuesSync:
         for a in client.export_annotations_to_file(queue_id=qid, export_format=export_format):
             result += a
 
-        http_client.export.assert_called_with("queues", qid, export_format)
+        http_client.export.assert_called_with(Resource.Queue, qid, export_format)
 
         with open("tests/data/annotation_export.xml", "rb") as fp:
             for i, line in enumerate(fp.read()):

--- a/tests/elis_api_client/test_schemas.py
+++ b/tests/elis_api_client/test_schemas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from rossum_api.api_client import Resource
 from rossum_api.models.schema import Schema
 
 
@@ -45,7 +46,7 @@ class TestSchemas:
         async for s in schemas:
             assert s == Schema(**dummy_schema)
 
-        http_client.fetch_all.assert_called_with("schemas", ())
+        http_client.fetch_all.assert_called_with(Resource.Schema, ())
 
     async def test_retrieve_schema(self, elis_client, dummy_schema):
         client, http_client = elis_client
@@ -56,7 +57,7 @@ class TestSchemas:
 
         assert schema == Schema(**dummy_schema)
 
-        http_client.fetch_one.assert_called_with("schemas", sid)
+        http_client.fetch_one.assert_called_with(Resource.Schema, sid)
 
     async def test_create_new_schema(self, elis_client, dummy_schema):
         client, http_client = elis_client
@@ -67,7 +68,7 @@ class TestSchemas:
 
         assert schema == Schema(**dummy_schema)
 
-        http_client.create.assert_called_with("schemas", data)
+        http_client.create.assert_called_with(Resource.Schema, data)
 
     async def test_delete_schema(self, elis_client, dummy_schema):
         client, http_client = elis_client
@@ -76,7 +77,7 @@ class TestSchemas:
         sid = dummy_schema["id"]
         await client.delete_schema(sid)
 
-        http_client.delete.assert_called_with("schemas", sid)
+        http_client.delete.assert_called_with(Resource.Schema, sid)
 
 
 class TestSchemasSync:
@@ -89,7 +90,7 @@ class TestSchemasSync:
         for s in schemas:
             assert s == Schema(**dummy_schema)
 
-        http_client.fetch_all.assert_called_with("schemas", ())
+        http_client.fetch_all.assert_called_with(Resource.Schema, ())
 
     def test_retrieve_schema(self, elis_client_sync, dummy_schema):
         client, http_client = elis_client_sync
@@ -100,7 +101,7 @@ class TestSchemasSync:
 
         assert schema == Schema(**dummy_schema)
 
-        http_client.fetch_one.assert_called_with("schemas", sid)
+        http_client.fetch_one.assert_called_with(Resource.Schema, sid)
 
     def test_create_new_schema(self, elis_client_sync, dummy_schema):
         client, http_client = elis_client_sync
@@ -111,7 +112,7 @@ class TestSchemasSync:
 
         assert schema == Schema(**dummy_schema)
 
-        http_client.create.assert_called_with("schemas", data)
+        http_client.create.assert_called_with(Resource.Schema, data)
 
     def test_delete_schema(self, elis_client_sync, dummy_schema):
         client, http_client = elis_client_sync
@@ -120,4 +121,4 @@ class TestSchemasSync:
         sid = dummy_schema["id"]
         client.delete_schema(sid)
 
-        http_client.delete.assert_called_with("schemas", sid)
+        http_client.delete.assert_called_with(Resource.Schema, sid)

--- a/tests/elis_api_client/test_user_roles.py
+++ b/tests/elis_api_client/test_user_roles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from rossum_api.api_client import Resource
 from rossum_api.models.user_role import UserRole
 
 
@@ -21,7 +22,7 @@ class TestWorkspaces:
         async for u in user_roles:
             assert u == UserRole(**dummy_user_role)
 
-        http_client.fetch_all.assert_called_with("groups", ())
+        http_client.fetch_all.assert_called_with(Resource.Group, ())
 
 
 class TestWorkspacesAsync:
@@ -34,4 +35,4 @@ class TestWorkspacesAsync:
         for u in user_roles:
             assert u == UserRole(**dummy_user_role)
 
-        http_client.fetch_all.assert_called_with("groups", ())
+        http_client.fetch_all.assert_called_with(Resource.Group, ())

--- a/tests/elis_api_client/test_users.py
+++ b/tests/elis_api_client/test_users.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from rossum_api.api_client import Resource
 from rossum_api.models.user import User
 
 
@@ -16,7 +17,7 @@ class TestUsers:
         async for u in users:
             assert u == User(**dummy_user)
 
-        http_client.fetch_all.assert_called_with("users", ())
+        http_client.fetch_all.assert_called_with(Resource.User, ())
 
     async def test_retrieve_user(self, elis_client, dummy_user):
         client, http_client = elis_client
@@ -27,7 +28,7 @@ class TestUsers:
 
         assert user == User(**dummy_user)
 
-        http_client.fetch_one.assert_called_with("users", uid)
+        http_client.fetch_one.assert_called_with(Resource.User, uid)
 
     async def test_create_new_user(self, elis_client, dummy_user):
         client, http_client = elis_client
@@ -44,7 +45,7 @@ class TestUsers:
 
         assert user == User(**dummy_user)
 
-        http_client.create.assert_called_with("users", data)
+        http_client.create.assert_called_with(Resource.User, data)
 
 
 class TestUsersSync:
@@ -57,7 +58,7 @@ class TestUsersSync:
         for u in users:
             assert u == User(**dummy_user)
 
-        http_client.fetch_all.assert_called_with("users", ())
+        http_client.fetch_all.assert_called_with(Resource.User, ())
 
     def test_retrieve_user(self, elis_client_sync, dummy_user):
         client, http_client = elis_client_sync
@@ -68,7 +69,7 @@ class TestUsersSync:
 
         assert user == User(**dummy_user)
 
-        http_client.fetch_one.assert_called_with("users", uid)
+        http_client.fetch_one.assert_called_with(Resource.User, uid)
 
     def test_create_new_user(self, elis_client_sync, dummy_user):
         client, http_client = elis_client_sync
@@ -85,4 +86,4 @@ class TestUsersSync:
 
         assert user == User(**dummy_user)
 
-        http_client.create.assert_called_with("users", data)
+        http_client.create.assert_called_with(Resource.User, data)

--- a/tests/elis_api_client/test_workspaces.py
+++ b/tests/elis_api_client/test_workspaces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from rossum_api.api_client import Resource
 from rossum_api.models.workspace import Workspace
 
 
@@ -32,7 +33,7 @@ class TestWorkspaces:
         async for w in workspaces:
             assert w == Workspace(**dummy_workspace)
 
-        http_client.fetch_all.assert_called_with("workspaces", ())
+        http_client.fetch_all.assert_called_with(Resource.Workspace, ())
 
     async def test_retrieve_workspace(self, elis_client, dummy_workspace):
         client, http_client = elis_client
@@ -43,7 +44,7 @@ class TestWorkspaces:
 
         assert workspace == Workspace(**dummy_workspace)
 
-        http_client.fetch_one.assert_called_with("workspaces", oid)
+        http_client.fetch_one.assert_called_with(Resource.Workspace, oid)
 
     async def test_create_new_workspace(self, elis_client, dummy_workspace):
         client, http_client = elis_client
@@ -58,7 +59,7 @@ class TestWorkspaces:
 
         assert workspace == Workspace(**dummy_workspace)
 
-        http_client.create.assert_called_with("workspaces", data)
+        http_client.create.assert_called_with(Resource.Workspace, data)
 
     async def test_delete_workspace(self, elis_client, dummy_workspace):
         client, http_client = elis_client
@@ -67,7 +68,7 @@ class TestWorkspaces:
         oid = dummy_workspace["id"]
         await client.delete_workspace(oid)
 
-        http_client.delete.assert_called_with("workspaces", oid)
+        http_client.delete.assert_called_with(Resource.Workspace, oid)
 
 
 class TestWorkspacesSync:
@@ -80,7 +81,7 @@ class TestWorkspacesSync:
         for w in workspaces:
             assert w == Workspace(**dummy_workspace)
 
-        http_client.fetch_all.assert_called_with("workspaces", ())
+        http_client.fetch_all.assert_called_with(Resource.Workspace, ())
 
     def test_retrieve_workspace(self, elis_client_sync, dummy_workspace):
         client, http_client = elis_client_sync
@@ -91,7 +92,7 @@ class TestWorkspacesSync:
 
         assert workspace == Workspace(**dummy_workspace)
 
-        http_client.fetch_one.assert_called_with("workspaces", oid)
+        http_client.fetch_one.assert_called_with(Resource.Workspace, oid)
 
     def test_create_new_workspace(self, elis_client_sync, dummy_workspace):
         client, http_client = elis_client_sync
@@ -105,7 +106,7 @@ class TestWorkspacesSync:
 
         assert workspace == Workspace(**dummy_workspace)
 
-        http_client.create.assert_called_with("workspaces", data)
+        http_client.create.assert_called_with(Resource.Workspace, data)
 
     def test_delete_workspace(self, elis_client_sync, dummy_workspace):
         client, http_client = elis_client_sync
@@ -114,4 +115,4 @@ class TestWorkspacesSync:
         oid = dummy_workspace["id"]
         client.delete_workspace(oid)
 
-        http_client.delete.assert_called_with("workspaces", oid)
+        http_client.delete.assert_called_with(Resource.Workspace, oid)


### PR DESCRIPTION
This is not only cleaner but will be useful when implementing custom de-serializers.