### PR TITLE
Draft: Add 'Publish to Pypi' github workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,70 @@
+name: PyPI Release
+
+# https://help.github.com/en/actions/reference/events-that-trigger-workflows
+on: # Trigger the workflow on push or pull request, but only for the master branch
+  push:
+    branches: [main, "release/*"]
+  pull_request:
+    branches: [main, "release/*"]
+    paths:
+      - ".github/workflows/publish-pkg.yml"
+  release:
+    types: [published]
+
+jobs:
+  # based on https://github.com/pypa/gh-action-pypi-publish
+  build-package:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install `build` dependency
+        run: python -m pip install -U build
+
+      - name: Build package
+        run: python -m build && ls -lh dist/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+
+  release-upload:
+    needs: build-package
+    if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+      - run: ls -lh dist/
+
+      - name: Upload to release
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "dist/*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-pypi-main:
+    needs: build-package
+    if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+      - run: ls -lh dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.12
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rossum_api"
-version = "1.0.0"
+version = "0.13.1"
 license = {text = "MIT"}
 readme = "README.md"
 dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from setuptools import setup
-
-__version__ = "0.7.2"
-
-setup(
-    version=__version__,
-)


### PR DESCRIPTION
Add 'Publish to Pypi' github workflow to facilitate the process of regular package re-pinning with `uv` (pip alternative).

## TODO:
- [ ] Create a dedicated page on PyPi
- [ ] Generate repo secrets