### PR TITLE
packaging: Use solely pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rossum_api"
-version = "1.0.0"
+version = "0.15.0"
 license = {text = "MIT"}
 readme = "README.md"
 dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from setuptools import setup
-
-__version__ = "0.7.2"
-
-setup(
-    version=__version__,
-)


### PR DESCRIPTION
Use solely pyproject.toml with a correctly specified package version and drop no more needed setup.py.

Fixes #58.