### PR TITLE
fix(api-client): do not reauth if no credentials are available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ help:
 	@echo "make install: Install all needed dependencies including tests"
 	@echo "make lint: Run linters"
 	@echo "make test: Run basic tests (not testing most integrations)"
-	@echo "make test-all: Run ALL tests (slow, closest to CI)"
 	@echo "make format: Run code formatters (destructive)"
 	@echo
 	@echo "Also make sure to read ./CONTRIBUTING.md"

--- a/rossum_api/api_client.py
+++ b/rossum_api/api_client.py
@@ -67,6 +67,8 @@ def authenticate_if_needed(method):
         except APIClientError as e:
             if e.status_code != 401:
                 raise
+            if not (self.username and self.password):  # no way to refresh token
+                raise
             logger.debug("Token expired, authenticating user %s...", self.username)
             await self._authenticate()
             return await method(self, *args, **kwargs)


### PR DESCRIPTION
Currently, the api client tries to re-authenticate using credentials (username + password) in case the token is invalid (401 response is received on any request). However, attempting this when there were no credentials configured when creating the client doesn't make sense. It results in a misleading 400 error saying `{"password": ["This field may not be blank."]}`.

This change fixes it by transparently returning the 401 when the token is invalid and the credentials are missing. This way, the code using the client can deal with the invalid token issue on its own (e.g. display a user friendly message).