### PR TITLE
Use venv pytest for the test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format: .venv
 .PHONY: format
 
 test: .venv
-	pytest tests
+	$(VENV_PATH)/bin/pytest tests
 .PHONY: test
 
 lint: .venv


### PR DESCRIPTION
Running just `pytest` goes after the default command on the path, at least on my Mac. Being more specific should make it work it for everyone.