### PR TITLE
fix: handle http:// urls for local development

### DIFF
--- a/rossum_api/api_client.py
+++ b/rossum_api/api_client.py
@@ -444,7 +444,7 @@ class APIClient:
             base URL is prepended with base_url if needed
         """
         # Do not force the calling site to always prepend the base URL
-        if not url.startswith("https://"):
+        if not url.startswith("https://") and not url.startswith("http://"):
             url = f"{self.base_url}/{url}"
         headers = kwargs.pop("headers", {})
         headers["Authorization"] = f"token {self.token}"
@@ -471,7 +471,7 @@ class APIClient:
     async def _stream(self, method: str, url: str, *args, **kwargs) -> AsyncIterator[bytes]:
         """Performs a streaming HTTP call."""
         # Do not force the calling site to alway prepend the base URL
-        if not url.startswith("https://"):
+        if not url.startswith("https://") and not url.startswith("http://"):
             url = f"{self.base_url}/{url}"
         headers = kwargs.pop("headers", {})
         headers["Authorization"] = f"token {self.token}"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -698,6 +698,15 @@ async def test_request_json_full_url(client, httpx_mock):
 
 
 @pytest.mark.asyncio
+async def test_request_json_full_url_http(client, httpx_mock):
+    httpx_mock.add_response(
+        method="GET", url="http://localhost:8000/api/v1/workspaces/123", json=WORKSPACES[0]
+    )
+    data = await client.request_json("GET", "http://localhost:8000/api/v1/workspaces/123")
+    assert data == WORKSPACES[0]
+
+
+@pytest.mark.asyncio
 async def test_request_json_204(client, httpx_mock):
     httpx_mock.add_response(
         method="DELETE", url="https://elis.rossum.ai/api/v1/workspaces/123", status_code=204


### PR DESCRIPTION
This fixes the sdk prepending `http://` urls with `base_url`.