### PR TITLE
feat: Improve export helpers method, enrich exception inf

### DIFF
--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -204,23 +204,27 @@ class ElisAPIClient:
         upload = await self._http_client.fetch_one(Resource.Upload, upload_id)
         return self._deserializer(Resource.Upload, upload)
 
-    async def export_annotations_to_json(self, queue_id: int) -> AsyncIterator[Annotation]:
+    async def export_annotations_to_json(
+        self, queue_id: int, **filters: Any
+    ) -> AsyncIterator[Annotation]:
         """https://elis.rossum.ai/api/docs/#export-annotations.
 
         JSON export is paginated and returns the result in a way similar to other list_all methods.
         """
-        async for chunk in self._http_client.export(Resource.Queue, queue_id, "json"):
+        async for chunk in self._http_client.export(Resource.Queue, queue_id, "json", **filters):
             # JSON export can be translated directly to Annotation object
             yield self._deserializer(Resource.Annotation, typing.cast(typing.Dict, chunk))
 
     async def export_annotations_to_file(
-        self, queue_id: int, export_format: ExportFileFormats
+        self, queue_id: int, export_format: ExportFileFormats, **filters: Any
     ) -> AsyncIterator[bytes]:
         """https://elis.rossum.ai/api/docs/#export-annotations.
 
         XLSX/CSV/XML exports can be huge, therefore byte streaming is used to keep memory consumption low.
         """
-        async for chunk in self._http_client.export(Resource.Queue, queue_id, str(export_format)):
+        async for chunk in self._http_client.export(
+            Resource.Queue, queue_id, str(export_format), **filters
+        ):
             yield typing.cast(bytes, chunk)
 
     # ##### ORGANIZATIONS #####

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -207,22 +207,24 @@ class ElisAPIClientSync:
 
         return self._run_coroutine(self.elis_api_client.retrieve_upload(upload_id))
 
-    def export_annotations_to_json(self, queue_id: int) -> Iterator[Annotation]:
+    def export_annotations_to_json(self, queue_id: int, **filters: Any) -> Iterator[Annotation]:
         """https://elis.rossum.ai/api/docs/#export-annotations.
 
         JSON export is paginated and returns the result in a way similar to other list_all methods.
         """
-        return self._iter_over_async(self.elis_api_client.export_annotations_to_json(queue_id))
+        return self._iter_over_async(
+            self.elis_api_client.export_annotations_to_json(queue_id, **filters)
+        )
 
     def export_annotations_to_file(
-        self, queue_id: int, export_format: ExportFileFormats
+        self, queue_id: int, export_format: ExportFileFormats, **filters: Any
     ) -> Iterator[bytes]:
         """https://elis.rossum.ai/api/docs/#export-annotations.
 
         XLSX/CSV/XML exports can be huge, therefore byte streaming is used to keep memory consumption low.
         """
         return self._iter_over_async(
-            self.elis_api_client.export_annotations_to_file(queue_id, export_format)
+            self.elis_api_client.export_annotations_to_file(queue_id, export_format, **filters)
         )
 
     # ##### ORGANIZATIONS #####

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -699,7 +699,10 @@ async def test_request_repacks_exception(client, httpx_mock):
     )
     with pytest.raises(APIClientError) as err:
         await client._request("GET", "workspaces/123")
-    assert str(err.value) == 'HTTP 404, content: {"detail":"Not found."}'
+    assert str(err.value) == (
+        "[GET] https://elis.rossum.ai/api/v1/workspaces/123 - "
+        'HTTP 404 - {"detail":"Not found."}'
+    )
 
 
 @pytest.mark.asyncio
@@ -713,7 +716,10 @@ async def test_stream_repacks_exception(client, httpx_mock):
     with pytest.raises(APIClientError) as err:
         async for _w in client._stream("GET", "queues/123/export?format=csv&exported_at=invalid"):
             pass
-    assert str(err.value) == "HTTP 404, content: exported_at: Enter a valid date/time"
+    assert str(err.value) == (
+        "[GET] https://elis.rossum.ai/api/v1/queues/123/export?format=csv&exported_at=invalid "
+        "- HTTP 404 - exported_at: Enter a valid date/time"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Per EXE-2704.

1. Both export methods were not allowing filters, fixed that.
2. Some clients use more information from the exception and were wrapping APIClientError, which was unfortunate. Let me know if I should reformat it somehow, there is definitely wiggle room on this change.