### PR TITLE
refactor: Rename retrieve_engine_queue_stats to retrieve_engine_queues

### DIFF
--- a/rossum_api/elis_api_client.py
+++ b/rossum_api/elis_api_client.py
@@ -557,8 +557,8 @@ class ElisAPIClient:
         ):
             yield self._deserializer(Resource.EngineField, engine_field)
 
-    async def retrieve_engine_queue_stats(self, engine_id: int) -> AsyncIterator[Queue]:
-        """https://elis.rossum.ai/api/docs/internal/#get-queue-statistics-for-an-engine."""
+    async def retrieve_engine_queues(self, engine_id: int) -> AsyncIterator[Queue]:
+        """https://elis.rossum.ai/api/docs/internal/#list-all-queues."""
         async for queue in self._http_client.fetch_all(Resource.Queue, engine=engine_id):
             yield self._deserializer(Resource.Queue, queue)
 

--- a/rossum_api/elis_api_client_sync.py
+++ b/rossum_api/elis_api_client_sync.py
@@ -281,9 +281,9 @@ class ElisAPIClientSync:
         """https://elis.rossum.ai/api/docs/internal/#engine-field."""
         return self._iter_over_async(self.elis_api_client.retrieve_engine_fields(engine_id))
 
-    def retrieve_engine_queue_stats(self, engine_id: int) -> Iterator[Queue]:
-        """https://elis.rossum.ai/api/docs/internal/#get-queue-statistics-for-an-engine."""
-        return self._iter_over_async(self.elis_api_client.retrieve_engine_queue_stats(engine_id))
+    def retrieve_engine_queues(self, engine_id: int) -> Iterator[Queue]:
+        """https://elis.rossum.ai/api/docs/internal/#list-all-queues."""
+        return self._iter_over_async(self.elis_api_client.retrieve_engine_queues(engine_id))
 
     # ##### USERS #####
     def list_all_users(self, ordering: Sequence[str] = (), **filters: Any) -> Iterator[User]:

--- a/tests/elis_api_client/test_engines.py
+++ b/tests/elis_api_client/test_engines.py
@@ -44,11 +44,11 @@ class TestEngine:
 
         http_client.fetch_all.assert_called_with(Resource.Engine, (), ())
 
-    async def test_retrieve_engine_queue_stats(self, elis_client, dummy_queue, mock_generator):
+    async def test_retrieve_engine_queues(self, elis_client, dummy_queue, mock_generator):
         client, http_client = elis_client
         http_client.fetch_all.return_value = mock_generator(dummy_queue)
 
-        queues = client.retrieve_engine_queue_stats(TEST_ENGINE_ID)
+        queues = client.retrieve_engine_queues(TEST_ENGINE_ID)
 
         async for queue in queues:
             assert queue == Queue(**dummy_queue)


### PR DESCRIPTION
The new name better conveys the essence that we're retrieving only a **list of queues** associated with the **given engine**.