### PR TITLE
fix: switch from token header to Bearer auth and update tests

### DIFF
--- a/rossum_api/clients/internal_async_client.py
+++ b/rossum_api/clients/internal_async_client.py
@@ -78,7 +78,7 @@ class InternalAsyncClient:
 
     @property
     def _headers(self):
-        return {"Authorization": f"token {self.token}"}
+        return {"Authorization": f"Bearer {self.token}"}
 
     async def fetch_one(
         self, resource: Resource, id_: Union[int, str], request_params: Dict[str, Any] = None

--- a/rossum_api/clients/internal_sync_client.py
+++ b/rossum_api/clients/internal_sync_client.py
@@ -78,7 +78,7 @@ class InternalSyncClient:
 
     @property
     def _headers(self):
-        return {"Authorization": f"token {self.token}"}
+        return {"Authorization": f"Bearer {self.token}"}
 
     def create(self, resource: Resource, data: dict[str, Any]) -> dict[str, Any]:
         """Create a new object."""

--- a/tests/internal_clients/test_internal_async_client.py
+++ b/tests/internal_clients/test_internal_async_client.py
@@ -95,7 +95,7 @@ async def test_init_token(httpx_mock):
     )
     await client.fetch_one(Resource.User, 1)
     assert len(httpx_mock.get_requests()) == 1
-    assert httpx_mock.get_requests()[0].headers["Authorization"] == f"token {FAKE_TOKEN}"
+    assert httpx_mock.get_requests()[0].headers["Authorization"] == f"Bearer {FAKE_TOKEN}"
 
 
 @pytest.mark.asyncio
@@ -124,14 +124,14 @@ async def test_reauth_success(login_mock, httpx_mock):
         method="GET",
         url="https://elis.rossum.ai/api/v1/users/1",
         status_code=401,
-        match_headers={"Authorization": f"token {FAKE_TOKEN}"},
+        match_headers={"Authorization": f"Bearer {FAKE_TOKEN}"},
         content=b"unauth!",
     )
 
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/users/1",
-        match_headers={"Authorization": f"token {NEW_TOKEN}"},
+        match_headers={"Authorization": f"Bearer {NEW_TOKEN}"},
         json=USER,
     )
 
@@ -514,13 +514,13 @@ async def test_authenticate_if_needed_token_expired(client, httpx_mock):
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/workspaces/7694",
-        headers={"Authorization": "token fake-token"},
+        headers={"Authorization": "Bearer fake-token"},
         status_code=401,
     )
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/workspaces/7694",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         json=WORKSPACES[0],
     )
 
@@ -537,13 +537,13 @@ async def test_authenticate_generator_if_needed_token_expired(client, httpx_mock
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/queues/123/export?format=csv",
-        headers={"Authorization": "token fake-token"},
+        headers={"Authorization": "Bearer fake-token"},
         status_code=401,
     )
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/queues/123/export?format=csv",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         stream=pytest_httpx.IteratorStream([CSV_EXPORT[:20], CSV_EXPORT[20:]]),
     )
 
@@ -561,7 +561,7 @@ async def test_authenticate_if_needed_no_token(httpx_mock):
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/workspaces/7694",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         json=WORKSPACES[0],
     )
 
@@ -580,7 +580,7 @@ async def test_authenticate_generator_if_needed_no_token(client, httpx_mock):
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/queues/123/export?format=csv",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         stream=pytest_httpx.IteratorStream([CSV_EXPORT[:20], CSV_EXPORT[20:]]),
     )
 

--- a/tests/internal_clients/test_internal_sync_client.py
+++ b/tests/internal_clients/test_internal_sync_client.py
@@ -93,7 +93,7 @@ def test_init_token(httpx_mock):
     )
     client.fetch_resource(Resource.User, 1)
     assert len(httpx_mock.get_requests()) == 1
-    assert httpx_mock.get_requests()[0].headers["Authorization"] == f"token {FAKE_TOKEN}"
+    assert httpx_mock.get_requests()[0].headers["Authorization"] == f"Bearer {FAKE_TOKEN}"
 
 
 def test_reauth_no_credentials(httpx_mock):
@@ -414,13 +414,13 @@ def test_authenticate_if_needed_token_expired(client, httpx_mock):
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/workspaces/7694",
-        headers={"Authorization": "token fake-token"},
+        headers={"Authorization": "Bearer fake-token"},
         status_code=401,
     )
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/workspaces/7694",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         json=WORKSPACES[0],
     )
 
@@ -436,13 +436,13 @@ def test_authenticate_generator_if_needed_token_expired(client, httpx_mock):
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/queues/123/export?format=csv",
-        headers={"Authorization": "token fake-token"},
+        headers={"Authorization": "Bearer fake-token"},
         status_code=401,
     )
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/queues/123/export?format=csv",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         stream=pytest_httpx.IteratorStream([CSV_EXPORT[:20], CSV_EXPORT[20:]]),
     )
 
@@ -464,7 +464,7 @@ def test_authenticate_if_needed_no_token(httpx_mock):
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/workspaces/7694",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         json=WORKSPACES[0],
     )
 
@@ -487,7 +487,7 @@ def test_authenticate_generator_if_needed_no_token(client, httpx_mock):
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/queues/123/export?format=csv",
-        match_headers={"Authorization": "token new-token"},
+        match_headers={"Authorization": "Bearer new-token"},
         stream=pytest_httpx.IteratorStream([CSV_EXPORT[:20], CSV_EXPORT[20:]]),
     )
 


### PR DESCRIPTION
Based on the official documentation, the API supports "Bearer" together with "token". To standardize and allow easy extension of the SDK, it is proposed to run "Beared" instead of "token" as a part of the Header. 