### PR TITLE
feat: Add authenticate method to Rossum API client 

### DIFF
--- a/rossum_api/clients/external_async_client.py
+++ b/rossum_api/clients/external_async_client.py
@@ -819,6 +819,9 @@ class AsyncRossumAPIClient(
         """
         return await self._http_client.get_token(refresh)
 
+    async def authenticate(self) -> None:
+        await self._http_client._authenticate()
+
     async def _sideload(self, resource: Dict[str, Any], sideloads: Sequence[str]) -> None:
         """The API does not support sideloading when fetching a single resource, we need to load
         it manually.

--- a/rossum_api/clients/external_sync_client.py
+++ b/rossum_api/clients/external_sync_client.py
@@ -773,6 +773,9 @@ class SyncRossumAPIClient(
         for g in self.internal_client.fetch_resources(Resource.Group, ordering, **filters):
             yield self._deserializer(Resource.Group, g)
 
+    def authenticate(self) -> None:
+        self.internal_client._authenticate()
+
 
 # Type alias for an SyncRossumAPIClient that uses the default deserializer
 SyncRossumAPIClientWithDefaultDeserializer = SyncRossumAPIClient[


### PR DESCRIPTION
Add a missing `authenticate` method to **Rossum API client** (both **sync** and **async** versions) so that it can be called directly when testing whether credentials are properly set up.