### PR TITLE
fix: pass include_total on all paginated requests

### DIFF
--- a/rossum_api/clients/internal_async_client.py
+++ b/rossum_api/clients/internal_async_client.py
@@ -202,7 +202,11 @@ class InternalAsyncClient:
         async def _fetch_page(page_number: int) -> tuple[list[dict[str, Any]], int]:
             async with in_flight_guard:
                 return await self._fetch_page(
-                    url, method, {**query_params, "page": page_number}, sideloads, json=json
+                    url,
+                    method,
+                    {**query_params, "page": page_number, "include_total": "true"},
+                    sideloads,
+                    json=json,
                 )
 
         page_requests = [asyncio.create_task(_fetch_page(i)) for i in range(2, last_page + 1)]

--- a/rossum_api/clients/internal_sync_client.py
+++ b/rossum_api/clients/internal_sync_client.py
@@ -227,7 +227,11 @@ class InternalSyncClient:  # noqa: D101
 
         for page_number in range(2, last_page + 1):
             results, _ = self._fetch_page(
-                url, method, {**query_params, "page": page_number}, sideloads, json=json
+                url,
+                method,
+                {**query_params, "page": page_number, "include_total": "true"},
+                sideloads,
+                json=json,
             )
             yield from results
 

--- a/tests/internal_clients/test_internal_async_client.py
+++ b/tests/internal_clients/test_internal_async_client.py
@@ -195,8 +195,8 @@ async def test_fetch_one(client, httpx_mock):
 
 @pytest.mark.asyncio
 async def test_fetch_all(client, httpx_mock):
-    second_page = "https://elis.rossum.ai/api/v1/workspaces?page=2&page_size=100&ordering=&sideload=&content.schema_id="
-    third_page = "https://elis.rossum.ai/api/v1/workspaces?page=3&page_size=100&ordering=&sideload=&content.schema_id="
+    second_page = "https://elis.rossum.ai/api/v1/workspaces?page=2&page_size=100&ordering=&sideload=&content.schema_id=&include_total=true"
+    third_page = "https://elis.rossum.ai/api/v1/workspaces?page=3&page_size=100&ordering=&sideload=&content.schema_id=&include_total=true"
     httpx_mock.add_response(
         method="GET",
         url="https://elis.rossum.ai/api/v1/workspaces?page_size=100&ordering=&include_total=true&sideload=&content.schema_id=",
@@ -344,7 +344,7 @@ async def test_fetch_all_limit_in_flight_requests(client, httpx_mock):
     page_count = 10
     page_url = "https://elis.rossum.ai/api/v1/workspaces?page_size=100&ordering=&include_total=true&sideload=&content.schema_id="
     for i in range(2, page_count + 1):
-        next_page_url = f"https://elis.rossum.ai/api/v1/workspaces?page={i}&page_size=100&ordering=&sideload=&content.schema_id="
+        next_page_url = f"https://elis.rossum.ai/api/v1/workspaces?page={i}&page_size=100&ordering=&sideload=&content.schema_id=&include_total=true"
         httpx_mock.add_response(
             method="GET",
             url=page_url,
@@ -496,13 +496,13 @@ async def test_upload(client, httpx_mock):
             {},
             "GET",
             "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&columns=col1%2Ccol2&id=456%2C789&ordering=&include_total=true&sideload=&content.schema_id=",
-            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&columns=col1%2Ccol2&id=456%2C789&ordering=&sideload=&content.schema_id=",
+            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&include_total=true&columns=col1%2Ccol2&id=456%2C789&ordering=&sideload=&content.schema_id=",
         ),
         (
             {"to_status": "exported"},
             "POST",
             "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&columns=col1%2Ccol2&id=456%2C789&to_status=exported&ordering=&include_total=true&sideload=&content.schema_id=",
-            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&columns=col1%2Ccol2&id=456%2C789&to_status=exported&ordering=&sideload=&content.schema_id=",
+            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&include_total=true&columns=col1%2Ccol2&id=456%2C789&to_status=exported&ordering=&sideload=&content.schema_id=",
         ),
     ],
 )

--- a/tests/internal_clients/test_internal_sync_client.py
+++ b/tests/internal_clients/test_internal_sync_client.py
@@ -176,8 +176,8 @@ def test_fetch_resource(client, httpx_mock):
 
 def test_fetch_resources(client, httpx_mock):
     first_page = "https://elis.rossum.ai/api/v1/workspaces?page_size=100&ordering=&include_total=true&sideload=&content.schema_id="
-    second_page = "https://elis.rossum.ai/api/v1/workspaces?page=2&page_size=100&ordering=&sideload=&content.schema_id="
-    third_page = "https://elis.rossum.ai/api/v1/workspaces?page=3&page_size=100&ordering=&sideload=&content.schema_id="
+    second_page = "https://elis.rossum.ai/api/v1/workspaces?page=2&page_size=100&ordering=&sideload=&content.schema_id=&include_total=true"
+    third_page = "https://elis.rossum.ai/api/v1/workspaces?page=3&page_size=100&ordering=&sideload=&content.schema_id=&include_total=true"
     httpx_mock.add_response(
         method="GET",
         url=first_page,
@@ -414,13 +414,13 @@ def test_upload(client, httpx_mock):
             {},
             "GET",
             "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&include_total=true&columns=col1%2Ccol2&id=456%2C789&ordering=&sideload=&content.schema_id=",
-            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&columns=col1%2Ccol2&id=456%2C789&ordering=&sideload=&content.schema_id=",
+            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&include_total=true&columns=col1%2Ccol2&id=456%2C789&ordering=&sideload=&content.schema_id=",
         ),
         (
             {"to_status": "exported"},
             "POST",
             "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&include_total=true&columns=col1%2Ccol2&id=456%2C789&to_status=exported&ordering=&sideload=&content.schema_id=",
-            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&columns=col1%2Ccol2&id=456%2C789&to_status=exported&ordering=&sideload=&content.schema_id=",
+            "https://elis.rossum.ai/api/v1/queues/123/export?format=json&page_size=100&page=2&include_total=true&columns=col1%2Ccol2&id=456%2C789&to_status=exported&ordering=&sideload=&content.schema_id=",
         ),
     ],
 )


### PR DESCRIPTION
- `_fetch_page` reads `data["pagination"]["total_pages"]` but that key only exists when `include_total=true` is in the request params
- It was passed only on the first page, so everything with more than 1 page throws a `KeyError`
- Fix adds `include_total` to all page requests in both sync and async clients
